### PR TITLE
Add trim in capitalyzer

### DIFF
--- a/buttonHandler.js
+++ b/buttonHandler.js
@@ -133,6 +133,7 @@ function appendName(owner, cardName) {
 
 // Function to escape HTML entities
 function escapeHtml(text) {
+  text = text.trim();
   const map = {
     '&': '&amp;',
     '<': '&lt;',

--- a/remover.js
+++ b/remover.js
@@ -7,7 +7,7 @@ function removeElements(owner, itensList) {
   logThat(owner, 'Removing cards already in list:', '\n\n', '\n\n\n');
   cardDiv.forEach((cardDiv) => {
     const titleElement = cardDiv.querySelector('.title');
-    if (itensList.includes(titleElement.innerText)) {
+    if (itensList.includes(titleElement.innerText.trim())) {
       container.appendChild(cardDiv); // Add the matched div to the container
       logThat(owner, 'REMOVER: Moving \"' + titleElement.innerText + '\" card to the bottom.', '', '');
     }


### PR DESCRIPTION
Adding the trim function to the text capitaylizer, to remove spaces at both start and end of card names, to fix the bug of some cards beeing blocked but returning after reload.
The issue was caused becaused those card names are stored with spaced in the end.